### PR TITLE
Add voice-guided object search with cube overlay

### DIFF
--- a/Assets/Scripts/ObjectLabelController.cs
+++ b/Assets/Scripts/ObjectLabelController.cs
@@ -23,6 +23,23 @@ namespace Assets.Scripts
         /// </summary>
         public TextMeshPro TextMesh;
 
+        [Header("Cube Visualization")]
+        [Tooltip("Base scale for the solid cube that is placed on top of a recognized object.")]
+        [SerializeField]
+        private float cubeSize = 0.08f;
+
+        [Tooltip("Optional offset that is applied to the solid cube relative to the detection center.")]
+        [SerializeField]
+        private Vector3 cubeOffset = Vector3.zero;
+
+        [Tooltip("Default color that is used when no class specific color is provided.")]
+        [SerializeField]
+        private Color cubeDefaultColor = new Color(0.2f, 0.8f, 0.2f, 0.45f);
+
+        private GameObject detectionCube;
+        private MeshRenderer detectionCubeRenderer;
+        private MaterialPropertyBlock cubePropertyBlock;
+
         /// <summary>
         ///     Sets the display text.
         /// </summary>
@@ -30,7 +47,12 @@ namespace Assets.Scripts
         {
             set => this.TextMesh.text = value;
         }
-        
+
+        private void Awake()
+        {
+            this.EnsureCubeInitialized();
+        }
+
         /// <summary>
         ///     Updates the position of the object label.
         /// </summary>
@@ -42,6 +64,94 @@ namespace Assets.Scripts
             // update line between text and center of object
             this.LineRenderer.SetPosition(0, this.ContentParent.transform.position);
             this.LineRenderer.SetPosition(1, this.transform.position);
+        }
+
+        /// <summary>
+        ///     Updates the appearance of the solid cube that visualizes the detected object.
+        /// </summary>
+        /// <param name="color">Color that should be applied to the cube.</param>
+        /// <param name="size">Uniform size of the cube.</param>
+        public void UpdateCubeAppearance(Color color, float size)
+        {
+            this.EnsureCubeInitialized();
+
+            if (this.detectionCube != null)
+            {
+                this.detectionCube.SetActive(true);
+                this.detectionCube.transform.localPosition = this.cubeOffset;
+                this.detectionCube.transform.localScale = Vector3.one * Mathf.Max(0.001f, size);
+            }
+
+            if (this.detectionCubeRenderer == null)
+            {
+                return;
+            }
+
+            if (this.cubePropertyBlock == null)
+            {
+                this.cubePropertyBlock = new MaterialPropertyBlock();
+            }
+
+            this.cubePropertyBlock.SetColor("_Color", color);
+            this.detectionCubeRenderer.SetPropertyBlock(this.cubePropertyBlock);
+        }
+
+        /// <summary>
+        ///     Hides the visualization cube. This is useful when an item is removed or recycled.
+        /// </summary>
+        public void HideCube()
+        {
+            if (this.detectionCube != null)
+            {
+                this.detectionCube.SetActive(false);
+            }
+        }
+
+        private void EnsureCubeInitialized()
+        {
+            if (this.detectionCube != null && this.detectionCubeRenderer != null)
+            {
+                return;
+            }
+
+            Transform existingCube = this.transform.Find("DetectionCube");
+            if (existingCube != null)
+            {
+                this.detectionCube = existingCube.gameObject;
+                this.detectionCubeRenderer = this.detectionCube.GetComponent<MeshRenderer>();
+            }
+
+            if (this.detectionCube == null)
+            {
+                GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+                cube.name = "DetectionCube";
+                cube.transform.SetParent(this.transform, false);
+                cube.transform.localPosition = this.cubeOffset;
+                cube.transform.localRotation = Quaternion.identity;
+                cube.transform.localScale = Vector3.one * this.cubeSize;
+
+                Collider collider = cube.GetComponent<Collider>();
+                if (collider != null)
+                {
+                    Destroy(collider);
+                }
+
+                this.detectionCube = cube;
+                this.detectionCubeRenderer = cube.GetComponent<MeshRenderer>();
+            }
+
+            if (this.detectionCubeRenderer != null)
+            {
+                if (this.cubePropertyBlock == null)
+                {
+                    this.cubePropertyBlock = new MaterialPropertyBlock();
+                }
+
+                this.cubePropertyBlock.SetColor("_Color", this.cubeDefaultColor);
+                this.detectionCubeRenderer.SetPropertyBlock(this.cubePropertyBlock);
+                this.detectionCubeRenderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+                this.detectionCubeRenderer.receiveShadows = false;
+            }
         }
     }
 }

--- a/Assets/Scripts/VoiceCommandManager.cs
+++ b/Assets/Scripts/VoiceCommandManager.cs
@@ -1,0 +1,456 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using UnityEngine;
+#if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
+using UnityEngine.Windows.Speech;
+#endif
+
+namespace Assets.Scripts
+{
+    /// <summary>
+    ///     Configuration data for a voice command mapping.
+    /// </summary>
+    [Serializable]
+    public class VoiceCommandMapping
+    {
+        [Tooltip("Object class that should be triggered by this mapping.")]
+        public ObjectClass TargetClass;
+
+        [Tooltip("Friendly name that is used for voice feedback. Leave empty to use the enum name.")]
+        public string DisplayName;
+
+        [Tooltip("Phrases that trigger this mapping. They must match the recognition result exactly.")]
+        public string[] Phrases;
+    }
+
+    /// <summary>
+    ///     Handles speech recognition and maps phrases to object classes.
+    /// </summary>
+    public class VoiceCommandManager : MonoBehaviour
+    {
+        [Header("Voice Commands")]
+        [Tooltip("Custom voice command mappings. Leave empty to rely on the auto generated commands.")]
+        [SerializeField]
+        private VoiceCommandMapping[] commandMappings = new VoiceCommandMapping[0];
+
+        [Tooltip("Prefixes that are used to auto-generate additional commands such as 'find apple'.")]
+        [SerializeField]
+        private string[] defaultSearchPrefixes = new[] { "find", "look for", "search for", "i want to find" };
+
+        [Tooltip("Phrases that cancel the current search.")]
+        [SerializeField]
+        private string[] clearSearchCommands = new[] { "stop search", "cancel search", "clear search" };
+
+        [Tooltip("Automatically create commands for classes that are missing in the mapping list.")]
+        [SerializeField]
+        private bool autoGenerateMissingMappings = true;
+
+        [Tooltip("Log recognized phrases when running inside the Unity editor.")]
+        [SerializeField]
+        private bool logRecognizedPhrases = true;
+
+#if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
+        [Tooltip("Confidence level that is required before a phrase is accepted.")]
+        [SerializeField]
+        private ConfidenceLevel recognitionConfidence = ConfidenceLevel.Medium;
+
+        private KeywordRecognizer keywordRecognizer;
+#endif
+
+        private readonly Dictionary<string, VoiceCommandMapping> phraseLookup = new(StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<string> clearLookup = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<ObjectClass, VoiceCommandMapping> mappingByClass = new();
+
+        /// <summary>
+        ///     Gets the currently active target class that was requested via voice command.
+        /// </summary>
+        public ObjectClass? ActiveTarget { get; private set; }
+
+        /// <summary>
+        ///     Gets the friendly display name of the active target.
+        /// </summary>
+        public string ActiveTargetDisplayName { get; private set; }
+
+        /// <summary>
+        ///     Event that is raised when the user requests a search.
+        /// </summary>
+        public event Action<ObjectClass, string> SearchRequested;
+
+        /// <summary>
+        ///     Event that is raised when the user cancels the current search.
+        /// </summary>
+        public event Action SearchCleared;
+
+        private void Awake()
+        {
+            this.BuildLookup();
+        }
+
+        private void OnEnable()
+        {
+            this.StartRecognizer();
+        }
+
+        private void OnDisable()
+        {
+            this.StopRecognizer();
+        }
+
+        private void OnDestroy()
+        {
+            this.StopRecognizer();
+        }
+
+        /// <summary>
+        ///     Allows external systems to override the command mappings at runtime.
+        /// </summary>
+        /// <param name="mappings">New voice command mappings.</param>
+        public void ConfigureMappings(IEnumerable<VoiceCommandMapping> mappings)
+        {
+            this.commandMappings = mappings != null ? mappings.ToArray() : new VoiceCommandMapping[0];
+            this.BuildLookup();
+            this.RestartRecognizerIfNeeded();
+        }
+
+        /// <summary>
+        ///     Requests a search programmatically. This is useful for UI buttons.
+        /// </summary>
+        /// <param name="targetClass">Class that should be searched.</param>
+        /// <param name="displayName">Optional friendly name.</param>
+        public void RequestSearchFor(ObjectClass targetClass, string displayName = null)
+        {
+            this.EnsureMappings();
+
+            VoiceCommandMapping mapping;
+            if (!this.mappingByClass.TryGetValue(targetClass, out mapping))
+            {
+                mapping = this.CreateDefaultMapping(targetClass);
+                this.mappingByClass[targetClass] = mapping;
+            }
+
+            string resolvedName = string.IsNullOrWhiteSpace(displayName)
+                ? this.ResolveDisplayName(mapping)
+                : displayName.Trim();
+
+            this.ActiveTarget = targetClass;
+            this.ActiveTargetDisplayName = resolvedName;
+            this.SearchRequested?.Invoke(targetClass, resolvedName);
+        }
+
+        /// <summary>
+        ///     Clears the current search request.
+        /// </summary>
+        public void ClearSearch()
+        {
+            if (!this.ActiveTarget.HasValue)
+            {
+                return;
+            }
+
+            this.ActiveTarget = null;
+            this.ActiveTargetDisplayName = null;
+            this.SearchCleared?.Invoke();
+        }
+
+        /// <summary>
+        ///     Returns the friendly display name for a given class.
+        /// </summary>
+        /// <param name="objectClass">Class that should be resolved.</param>
+        /// <returns>Friendly name.</returns>
+        public string GetDisplayName(ObjectClass objectClass)
+        {
+            this.EnsureMappings();
+
+            VoiceCommandMapping mapping;
+            if (this.mappingByClass.TryGetValue(objectClass, out mapping))
+            {
+                return this.ResolveDisplayName(mapping);
+            }
+
+            return this.CreateFriendlyName(objectClass.ToString());
+        }
+
+        private void BuildLookup()
+        {
+            this.phraseLookup.Clear();
+            this.clearLookup.Clear();
+            this.mappingByClass.Clear();
+
+            if (this.commandMappings != null)
+            {
+                foreach (VoiceCommandMapping mapping in this.commandMappings)
+                {
+                    this.RegisterMapping(mapping);
+                }
+            }
+
+            if (this.autoGenerateMissingMappings)
+            {
+                foreach (ObjectClass objectClass in Enum.GetValues(typeof(ObjectClass)))
+                {
+                    if (this.mappingByClass.ContainsKey(objectClass))
+                    {
+                        continue;
+                    }
+
+                    VoiceCommandMapping mapping = this.CreateDefaultMapping(objectClass);
+                    this.RegisterMapping(mapping);
+                }
+            }
+
+            if (this.clearSearchCommands != null)
+            {
+                foreach (string command in this.clearSearchCommands)
+                {
+                    string normalized = this.NormalizePhrase(command);
+                    if (string.IsNullOrEmpty(normalized))
+                    {
+                        continue;
+                    }
+
+                    this.clearLookup.Add(normalized);
+                }
+            }
+        }
+
+        private void RegisterMapping(VoiceCommandMapping mapping)
+        {
+            if (mapping == null)
+            {
+                return;
+            }
+
+            mapping.DisplayName = this.ResolveDisplayName(mapping);
+            this.mappingByClass[mapping.TargetClass] = mapping;
+
+            bool hasCustomPhrase = false;
+            if (mapping.Phrases != null)
+            {
+                foreach (string phrase in mapping.Phrases)
+                {
+                    string normalized = this.NormalizePhrase(phrase);
+                    if (string.IsNullOrEmpty(normalized))
+                    {
+                        continue;
+                    }
+
+                    this.phraseLookup[normalized] = mapping;
+                    hasCustomPhrase = true;
+                }
+            }
+
+            string displayPhrase = this.NormalizePhrase(mapping.DisplayName);
+            if (!string.IsNullOrEmpty(displayPhrase))
+            {
+                this.phraseLookup[displayPhrase] = mapping;
+            }
+
+            if (!hasCustomPhrase && this.autoGenerateMissingMappings)
+            {
+                this.RegisterGeneratedPhrases(mapping, mapping.DisplayName);
+            }
+            else if (mapping.Phrases != null && mapping.Phrases.Length > 0)
+            {
+                this.RegisterGeneratedPhrases(mapping, mapping.DisplayName);
+            }
+        }
+
+        private void RegisterGeneratedPhrases(VoiceCommandMapping mapping, string basePhrase)
+        {
+            if (this.defaultSearchPrefixes == null)
+            {
+                return;
+            }
+
+            foreach (string prefix in this.defaultSearchPrefixes)
+            {
+                string generated = this.NormalizePhrase(string.Format("{0} {1}", prefix, basePhrase));
+                if (string.IsNullOrEmpty(generated))
+                {
+                    continue;
+                }
+
+                if (!this.phraseLookup.ContainsKey(generated))
+                {
+                    this.phraseLookup.Add(generated, mapping);
+                }
+            }
+        }
+
+        private VoiceCommandMapping CreateDefaultMapping(ObjectClass objectClass)
+        {
+            string displayName = this.CreateFriendlyName(objectClass.ToString());
+
+            List<string> phrases = new();
+            phrases.Add(displayName);
+
+            if (this.defaultSearchPrefixes != null)
+            {
+                foreach (string prefix in this.defaultSearchPrefixes)
+                {
+                    phrases.Add(string.Format("{0} {1}", prefix, displayName));
+                }
+            }
+
+            return new VoiceCommandMapping
+            {
+                TargetClass = objectClass,
+                DisplayName = displayName,
+                Phrases = phrases.ToArray()
+            };
+        }
+
+        private string ResolveDisplayName(VoiceCommandMapping mapping)
+        {
+            if (mapping == null)
+            {
+                return string.Empty;
+            }
+
+            if (!string.IsNullOrWhiteSpace(mapping.DisplayName))
+            {
+                return mapping.DisplayName.Trim();
+            }
+
+            return this.CreateFriendlyName(mapping.TargetClass.ToString());
+        }
+
+        private string CreateFriendlyName(string rawName)
+        {
+            if (string.IsNullOrWhiteSpace(rawName))
+            {
+                return string.Empty;
+            }
+
+            string withSpaces = Regex.Replace(rawName, "([a-z])([A-Z])", "$1 $2");
+            withSpaces = withSpaces.Replace('_', ' ');
+            return withSpaces.Trim();
+        }
+
+        private string NormalizePhrase(string phrase)
+        {
+            if (string.IsNullOrWhiteSpace(phrase))
+            {
+                return string.Empty;
+            }
+
+            return phrase.Trim().ToLowerInvariant();
+        }
+
+        private void EnsureMappings()
+        {
+            if (this.mappingByClass.Count == 0 && (this.commandMappings == null || this.commandMappings.Length == 0))
+            {
+                this.BuildLookup();
+            }
+        }
+
+        private void RestartRecognizerIfNeeded()
+        {
+#if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
+            if (this.keywordRecognizer != null)
+            {
+                bool wasRunning = this.keywordRecognizer.IsRunning;
+                this.StopRecognizer();
+                if (wasRunning)
+                {
+                    this.StartRecognizer();
+                }
+            }
+#endif
+        }
+
+        private void StartRecognizer()
+        {
+#if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
+            if (this.keywordRecognizer != null)
+            {
+                if (!this.keywordRecognizer.IsRunning)
+                {
+                    this.keywordRecognizer.Start();
+                }
+
+                return;
+            }
+
+            if (this.phraseLookup.Count == 0 && this.clearLookup.Count == 0)
+            {
+                if (Application.isEditor && this.logRecognizedPhrases)
+                {
+                    Debug.LogWarning($"{nameof(VoiceCommandManager)} has no voice commands configured.");
+                }
+
+                return;
+            }
+
+            string[] keywords = this.phraseLookup.Keys.Concat(this.clearLookup).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+            this.keywordRecognizer = new KeywordRecognizer(keywords, this.recognitionConfidence);
+            this.keywordRecognizer.OnPhraseRecognized += this.HandlePhraseRecognized;
+            this.keywordRecognizer.Start();
+#else
+            if (Application.isEditor && this.logRecognizedPhrases)
+            {
+                Debug.LogWarning($"{nameof(VoiceCommandManager)} voice recognition is only available on Windows-based targets.");
+            }
+#endif
+        }
+
+        private void StopRecognizer()
+        {
+#if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
+            if (this.keywordRecognizer == null)
+            {
+                return;
+            }
+
+            if (this.keywordRecognizer.IsRunning)
+            {
+                this.keywordRecognizer.Stop();
+            }
+
+            this.keywordRecognizer.OnPhraseRecognized -= this.HandlePhraseRecognized;
+            this.keywordRecognizer.Dispose();
+            this.keywordRecognizer = null;
+#endif
+        }
+
+#if UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
+        private void HandlePhraseRecognized(PhraseRecognizedEventArgs args)
+        {
+            string normalized = this.NormalizePhrase(args.text);
+            if (string.IsNullOrEmpty(normalized))
+            {
+                return;
+            }
+
+            if (this.clearLookup.Contains(normalized))
+            {
+                if (this.logRecognizedPhrases)
+                {
+                    Debug.Log($"[VoiceCommandManager] Clear command recognized: {args.text}");
+                }
+
+                this.ClearSearch();
+                return;
+            }
+
+            VoiceCommandMapping mapping;
+            if (!this.phraseLookup.TryGetValue(normalized, out mapping))
+            {
+                return;
+            }
+
+            if (this.logRecognizedPhrases)
+            {
+                Debug.Log($"[VoiceCommandManager] Recognized search command: {args.text}");
+            }
+
+            this.ActiveTarget = mapping.TargetClass;
+            this.ActiveTargetDisplayName = this.ResolveDisplayName(mapping);
+            this.SearchRequested?.Invoke(mapping.TargetClass, this.ActiveTargetDisplayName);
+        }
+#endif
+    }
+}

--- a/Assets/Scripts/VoiceCommandManager.cs.meta
+++ b/Assets/Scripts/VoiceCommandManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: deaac2d083454d9daa05f5efd747f3f8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/VoiceFeedbackController.cs
+++ b/Assets/Scripts/VoiceFeedbackController.cs
@@ -1,0 +1,318 @@
+using System;
+using UnityEngine;
+#if WINDOWS_UWP
+using System.Threading.Tasks;
+using Windows.Media.SpeechSynthesis;
+using Windows.Storage.Streams;
+#endif
+
+namespace Assets.Scripts
+{
+    /// <summary>
+    ///     Coordinates the voice guided search workflow by combining speech recognition, feedback and YOLO detections.
+    /// </summary>
+    [RequireComponent(typeof(AudioSource))]
+    public class VoiceFeedbackController : MonoBehaviour
+    {
+        [Header("Dependencies")]
+        [SerializeField]
+        private VoiceCommandManager voiceCommandManager;
+
+        [SerializeField]
+        private YoloRecognitionHandler recognitionHandler;
+
+        [SerializeField]
+        private AudioSource audioSource;
+
+        [Header("Speech Content")]
+        [SerializeField]
+        private bool announceSearchStart = true;
+
+        [SerializeField]
+        private string searchStartedFormat = "开始寻找{0}";
+
+        [SerializeField]
+        private string targetFoundFormat = "找到了{0}";
+
+        [SerializeField]
+        private string targetNotFoundFormat = "当前视野内没有{0}，请到其他位置尝试";
+
+        [Header("Timing")]
+        [Tooltip("Delay in seconds before the system informs the user that the target was not found.")]
+        [SerializeField]
+        private float notFoundAnnouncementDelay = 5f;
+
+        [Tooltip("Minimum time between repeated 'not found' notifications.")]
+        [SerializeField]
+        private float notFoundRepeatDelay = 12f;
+
+        [Tooltip("Minimum time between repeated 'found' notifications.")]
+        [SerializeField]
+        private float foundRepeatCooldown = 6f;
+
+        [SerializeField]
+        private bool logSpeechInEditor = true;
+
+#if WINDOWS_UWP
+        private SpeechSynthesizer speechSynthesizer;
+        private Task speechQueue = Task.CompletedTask;
+#endif
+
+        private ObjectClass? currentTarget;
+        private string currentTargetName;
+        private float lastDetectionTime;
+        private float lastNotFoundAnnouncement = float.NegativeInfinity;
+        private float lastFoundAnnouncement = float.NegativeInfinity;
+
+        private void Awake()
+        {
+            if (this.voiceCommandManager == null)
+            {
+                this.voiceCommandManager = FindObjectOfType<VoiceCommandManager>();
+            }
+
+            if (this.recognitionHandler == null)
+            {
+                this.recognitionHandler = GetComponent<YoloRecognitionHandler>();
+            }
+
+            if (this.audioSource == null)
+            {
+                this.audioSource = GetComponent<AudioSource>();
+            }
+
+            if (this.audioSource == null)
+            {
+                this.audioSource = this.gameObject.AddComponent<AudioSource>();
+            }
+
+            this.audioSource.playOnAwake = false;
+            this.audioSource.loop = false;
+        }
+
+        private void OnEnable()
+        {
+            if (this.voiceCommandManager != null)
+            {
+                this.voiceCommandManager.SearchRequested += this.HandleSearchRequested;
+                this.voiceCommandManager.SearchCleared += this.HandleSearchCleared;
+            }
+
+            if (this.recognitionHandler != null)
+            {
+                this.recognitionHandler.ItemUpdated += this.HandleItemUpdated;
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (this.voiceCommandManager != null)
+            {
+                this.voiceCommandManager.SearchRequested -= this.HandleSearchRequested;
+                this.voiceCommandManager.SearchCleared -= this.HandleSearchCleared;
+            }
+
+            if (this.recognitionHandler != null)
+            {
+                this.recognitionHandler.ItemUpdated -= this.HandleItemUpdated;
+            }
+        }
+
+        private void Update()
+        {
+            if (!this.currentTarget.HasValue)
+            {
+                return;
+            }
+
+            float timeSinceLastDetection = Time.time - this.lastDetectionTime;
+            if (timeSinceLastDetection < this.notFoundAnnouncementDelay)
+            {
+                return;
+            }
+
+            if (Time.time - this.lastNotFoundAnnouncement < this.notFoundRepeatDelay)
+            {
+                return;
+            }
+
+            this.Announce(string.Format(this.targetNotFoundFormat, this.currentTargetName));
+            this.lastNotFoundAnnouncement = Time.time;
+        }
+
+        /// <summary>
+        ///     Starts a search for the given class. This can be used by UI buttons when voice input is not available.
+        /// </summary>
+        public void StartSearch(ObjectClass target, string displayName = null)
+        {
+            string resolvedName = displayName;
+            if (string.IsNullOrWhiteSpace(resolvedName) && this.voiceCommandManager != null)
+            {
+                resolvedName = this.voiceCommandManager.GetDisplayName(target);
+            }
+
+            if (string.IsNullOrWhiteSpace(resolvedName))
+            {
+                resolvedName = target.ToString();
+            }
+
+            if (this.voiceCommandManager != null)
+            {
+                this.voiceCommandManager.RequestSearchFor(target, resolvedName);
+            }
+            else
+            {
+                this.HandleSearchRequested(target, resolvedName);
+            }
+        }
+
+        /// <summary>
+        ///     Stops the current search.
+        /// </summary>
+        public void StopSearch()
+        {
+            if (this.voiceCommandManager != null)
+            {
+                this.voiceCommandManager.ClearSearch();
+            }
+            else
+            {
+                this.HandleSearchCleared();
+            }
+        }
+
+        private void HandleSearchRequested(ObjectClass targetClass, string displayName)
+        {
+            string resolvedName = string.IsNullOrWhiteSpace(displayName) ? targetClass.ToString() : displayName;
+
+            this.currentTarget = targetClass;
+            this.currentTargetName = resolvedName;
+            this.lastDetectionTime = Time.time;
+            this.lastNotFoundAnnouncement = float.NegativeInfinity;
+            this.lastFoundAnnouncement = float.NegativeInfinity;
+
+            if (this.recognitionHandler != null)
+            {
+                this.recognitionHandler.SetActiveTarget(targetClass, resolvedName);
+            }
+
+            if (this.announceSearchStart)
+            {
+                this.Announce(string.Format(this.searchStartedFormat, resolvedName));
+            }
+        }
+
+        private void HandleSearchCleared()
+        {
+            if (this.recognitionHandler != null)
+            {
+                this.recognitionHandler.ClearActiveTarget();
+            }
+
+            this.currentTarget = null;
+            this.currentTargetName = null;
+        }
+
+        private void HandleItemUpdated(DisplayedItem item)
+        {
+            if (!this.currentTarget.HasValue)
+            {
+                return;
+            }
+
+            if (item.YoloItem.MostLikelyClass != this.currentTarget.Value)
+            {
+                return;
+            }
+
+            this.lastDetectionTime = Time.time;
+            this.lastNotFoundAnnouncement = float.NegativeInfinity;
+
+            if (Time.time - this.lastFoundAnnouncement < this.foundRepeatCooldown)
+            {
+                return;
+            }
+
+            this.Announce(string.Format(this.targetFoundFormat, this.currentTargetName));
+            this.lastFoundAnnouncement = Time.time;
+        }
+
+        private void Announce(string message)
+        {
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                return;
+            }
+
+#if WINDOWS_UWP
+            this.speechQueue = this.speechQueue.ContinueWith(_ => this.SpeakInternalAsync(message)).Unwrap();
+#else
+            if (this.logSpeechInEditor)
+            {
+                Debug.Log($"[VoiceFeedback] {message}");
+            }
+#endif
+        }
+
+#if WINDOWS_UWP
+        private async Task SpeakInternalAsync(string message)
+        {
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                return;
+            }
+
+            if (this.speechSynthesizer == null)
+            {
+                this.speechSynthesizer = new SpeechSynthesizer();
+            }
+
+            using (SpeechSynthesisStream speechStream = await this.speechSynthesizer.SynthesizeTextToStreamAsync(message))
+            using (DataReader dataReader = new DataReader(speechStream))
+            {
+                uint size = (uint)speechStream.Size;
+                await dataReader.LoadAsync(size);
+                byte[] buffer = new byte[size];
+                dataReader.ReadBytes(buffer);
+
+                int channelCount = (int)speechStream.AudioEncodingProperties.ChannelCount;
+                int sampleRate = (int)speechStream.AudioEncodingProperties.SampleRate;
+                int bytesPerSample = speechStream.AudioEncodingProperties.BitsPerSample / 8;
+                if (channelCount == 0 || bytesPerSample == 0)
+                {
+                    return;
+                }
+
+                int sampleCount = buffer.Length / bytesPerSample;
+                int sampleLength = sampleCount / channelCount;
+                float[] samples = new float[sampleCount];
+                int sampleIndex = 0;
+                for (int i = 0; i < buffer.Length; i += bytesPerSample)
+                {
+                    short sample = BitConverter.ToInt16(buffer, i);
+                    samples[sampleIndex++] = sample / 32768f;
+                }
+
+                var completion = new TaskCompletionSource<bool>();
+                UnityEngine.WSA.Application.InvokeOnAppThread(() =>
+                {
+                    try
+                    {
+                        AudioClip clip = AudioClip.Create("VoiceFeedback", sampleLength, channelCount, sampleRate, false);
+                        clip.SetData(samples, 0);
+                        this.audioSource.Stop();
+                        this.audioSource.clip = clip;
+                        this.audioSource.Play();
+                    }
+                    finally
+                    {
+                        completion.SetResult(true);
+                    }
+                }, false);
+
+                await completion.Task;
+            }
+        }
+#endif
+    }
+}

--- a/Assets/Scripts/VoiceFeedbackController.cs.meta
+++ b/Assets/Scripts/VoiceFeedbackController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0c61d23797cb45bdb6553f1034377277
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/YoloRecognitionHandler.cs
+++ b/Assets/Scripts/YoloRecognitionHandler.cs
@@ -15,11 +15,80 @@ namespace Assets.Scripts
         [SerializeField]
         private GameObject labelObject;
 
+        [Header("Voice Guided Search")]
+        [Tooltip("When enabled the visualizers will only show the detections that match the currently active target class.")]
+        [SerializeField]
+        private bool restrictDetectionsToActiveTarget = true;
+
+        [Tooltip("Highlight color that is applied to the cube when the detected item matches the requested target.")]
+        [SerializeField]
+        private Color targetHighlightColor = new Color(1f, 0.85f, 0.2f, 0.65f);
+
+        [Tooltip("Scale multiplier that is applied to the cube when the detected item matches the requested target.")]
+        [SerializeField]
+        private float targetCubeScaleMultiplier = 1.2f;
+
+        [Header("Cube Visualization")]
+        [Tooltip("Base cube size that will be used for all detections unless a class specific override is configured.")]
+        [SerializeField]
+        private float baseCubeSize = 0.08f;
+
+        [Tooltip("Default cube color that is used when no class specific override is available.")]
+        [SerializeField]
+        private Color defaultCubeColor = new Color(0.16f, 0.74f, 0.88f, 0.45f);
+
+        [SerializeField]
+        private ClassVisualizationSetting[] classVisualization = new ClassVisualizationSetting[0];
+
+        private readonly Dictionary<ObjectClass, ClassVisualizationSetting> classVisualizationLookup = new();
+
         private YoloDebugOutput yoloDebugOutput;
+        private ObjectClass? activeTargetClass;
+        private string activeTargetDisplayName;
+        private bool targetSeenInLastUpdate;
+
+        /// <summary>
+        ///     Event that is raised whenever an item is updated and has reached the minimum visibility threshold.
+        /// </summary>
+        public event Action<DisplayedItem> ItemUpdated;
+
+        /// <summary>
+        ///     Gets the currently active target class that is requested via voice search.
+        /// </summary>
+        public ObjectClass? ActiveTargetClass => this.activeTargetClass;
+
+        /// <summary>
+        ///     Gets the friendly display name of the active target class.
+        /// </summary>
+        public string ActiveTargetDisplayName => this.activeTargetDisplayName;
+
+        /// <summary>
+        ///     Tells whether the currently active target class was visible during the last update.
+        /// </summary>
+        public bool IsActiveTargetVisible => this.targetSeenInLastUpdate;
+
+        /// <summary>
+        ///     Provides read only access to the tracked items.
+        /// </summary>
+        public IReadOnlyList<DisplayedItem> DisplayedItems => this.yoloItems;
+
+        [Serializable]
+        private struct ClassVisualizationSetting
+        {
+            public ObjectClass TargetClass;
+            public Color CubeColor;
+            public float SizeMultiplier;
+        }
 
         private void Start()
         {
+            this.CacheClassVisualization();
             this.yoloDebugOutput = gameObject.GetComponent<YoloDebugOutput>();
+        }
+
+        private void OnValidate()
+        {
+            this.CacheClassVisualization();
         }
 
         /// <summary>
@@ -29,9 +98,46 @@ namespace Assets.Scripts
         /// <param name="cameraTransform">The current camera position.</param>
         public void ShowRecognitions(List<YoloItem> recognitions, CameraTransform cameraTransform)
         {
-            this.AddNewlyRecognizedObjects(recognitions, cameraTransform);
+            List<YoloItem> filteredRecognitions = this.FilterRecognitions(recognitions);
+
+            this.AddNewlyRecognizedObjects(filteredRecognitions, cameraTransform);
             this.RemoveOutdatedObjects();
             this.TriggerDetectionActions();
+        }
+
+        /// <summary>
+        ///     Sets the currently active target class that should be highlighted.
+        /// </summary>
+        /// <param name="targetClass">Target class to search for.</param>
+        /// <param name="displayName">Friendly display name used for logging.</param>
+        public void SetActiveTarget(ObjectClass targetClass, string displayName)
+        {
+            if (this.activeTargetClass.HasValue && this.activeTargetClass.Value == targetClass)
+            {
+                this.activeTargetDisplayName = displayName;
+                return;
+            }
+
+            this.activeTargetClass = targetClass;
+            this.activeTargetDisplayName = displayName;
+            this.targetSeenInLastUpdate = false;
+            this.ClearTrackedItems();
+        }
+
+        /// <summary>
+        ///     Clears the currently active target and shows all detections again.
+        /// </summary>
+        public void ClearActiveTarget()
+        {
+            if (!this.activeTargetClass.HasValue)
+            {
+                return;
+            }
+
+            this.activeTargetClass = null;
+            this.activeTargetDisplayName = null;
+            this.targetSeenInLastUpdate = false;
+            this.ClearTrackedItems();
         }
 
         private void AddNewlyRecognizedObjects(List<YoloItem> recognitions, CameraTransform cameraTransform)
@@ -123,22 +229,46 @@ namespace Assets.Scripts
                     continue;
                 }
 
-                Destroy(yoloItems[i].TrackingMarker);
+                if (yoloItems[i].TrackingMarker != null)
+                {
+                    ObjectLabelController controller = yoloItems[i].TrackingMarker.GetComponent<ObjectLabelController>();
+                    if (controller != null)
+                    {
+                        controller.HideCube();
+                    }
+
+                    Destroy(yoloItems[i].TrackingMarker);
+                }
+
                 this.yoloItems.RemoveAt(i);
             }
         }
 
         private void TriggerDetectionActions()
         {
+            bool targetSeenThisFrame = false;
+
             // Only apply actions if item have been seen multiple times.
-            foreach (DisplayedItem item in this.yoloItems.Where(item => item.IsInCameraView && item.TimesSeen >= Parameters.MinTimesSeen))
+            foreach (DisplayedItem item in this.yoloItems.Where(displayedItem => displayedItem.IsInCameraView && displayedItem.TimesSeen >= Parameters.MinTimesSeen))
             {
+                if (this.activeTargetClass.HasValue && item.YoloItem.MostLikelyClass == this.activeTargetClass.Value)
+                {
+                    targetSeenThisFrame = true;
+                }
+
                 // Show marker
                 this.ManageTrackingMarker(item);
 
                 // Show debug information
-                yoloDebugOutput.ShowDebugInformationForItem(item);
+                if (this.yoloDebugOutput != null)
+                {
+                    this.yoloDebugOutput.ShowDebugInformationForItem(item);
+                }
+
+                this.ItemUpdated?.Invoke(item);
             }
+
+            this.targetSeenInLastUpdate = this.activeTargetClass.HasValue && targetSeenThisFrame;
         }
 
         /// <summary>
@@ -155,7 +285,90 @@ namespace Assets.Scripts
             ObjectLabelController labelController = item.TrackingMarker.GetComponent<ObjectLabelController>();
             labelController.Text = $"{item.YoloItem.MostLikelyClass} ({Math.Round(item.YoloItem.Confidence * 100, 3)}%)";
             labelController.UpdatePosition(item.PositionInSpace);
-   
+
+            Color cubeColor = this.ResolveCubeColor(item.YoloItem.MostLikelyClass);
+            float cubeSize = this.ResolveCubeSize(item.YoloItem.MostLikelyClass);
+
+            if (this.activeTargetClass.HasValue && item.YoloItem.MostLikelyClass == this.activeTargetClass.Value)
+            {
+                cubeColor = this.targetHighlightColor;
+                cubeSize *= this.targetCubeScaleMultiplier;
+            }
+
+            labelController.UpdateCubeAppearance(cubeColor, cubeSize);
+        }
+
+        private List<YoloItem> FilterRecognitions(List<YoloItem> recognitions)
+        {
+            if (!this.restrictDetectionsToActiveTarget || !this.activeTargetClass.HasValue)
+            {
+                return recognitions;
+            }
+
+            return recognitions.Where(item => item.MostLikelyClass == this.activeTargetClass.Value).ToList();
+        }
+
+        private void ClearTrackedItems()
+        {
+            foreach (DisplayedItem item in this.yoloItems)
+            {
+                if (item.TrackingMarker != null)
+                {
+                    Destroy(item.TrackingMarker);
+                }
+            }
+
+            this.yoloItems.Clear();
+        }
+
+        private void CacheClassVisualization()
+        {
+            this.classVisualizationLookup.Clear();
+
+            if (this.classVisualization == null)
+            {
+                return;
+            }
+
+            foreach (ClassVisualizationSetting setting in this.classVisualization)
+            {
+                ClassVisualizationSetting sanitized = this.SanitizeSetting(setting);
+                this.classVisualizationLookup[sanitized.TargetClass] = sanitized;
+            }
+        }
+
+        private ClassVisualizationSetting SanitizeSetting(ClassVisualizationSetting setting)
+        {
+            ClassVisualizationSetting sanitized = setting;
+            if (sanitized.SizeMultiplier <= 0f)
+            {
+                sanitized.SizeMultiplier = 1f;
+            }
+
+            return sanitized;
+        }
+
+        private Color ResolveCubeColor(ObjectClass objectClass)
+        {
+            ClassVisualizationSetting setting;
+            if (this.classVisualizationLookup.TryGetValue(objectClass, out setting) && setting.CubeColor.a > 0.001f)
+            {
+                return setting.CubeColor;
+            }
+
+            return this.defaultCubeColor;
+        }
+
+        private float ResolveCubeSize(ObjectClass objectClass)
+        {
+            ClassVisualizationSetting setting;
+            if (this.classVisualizationLookup.TryGetValue(objectClass, out setting))
+            {
+                return this.baseCubeSize * setting.SizeMultiplier;
+            }
+
+            return this.baseCubeSize;
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- add a runtime solid cube visualization and highlighting support for detected objects
- introduce a voice command manager to filter detections by spoken class requests
- provide a voice feedback controller that announces search progress and results

## Testing
- not run (Unity environment)


------
https://chatgpt.com/codex/tasks/task_e_68d0128e88d08329bc7a04173e61de5b